### PR TITLE
update PlantUML version 8059 to 1.2021.9

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-plantuml "0.1.22"
+(defproject lein-plantuml "0.1.23-SNAPSHOT"
   :description "A Leiningen plugin for generating UML diagrams using PluntUML."
   :url "https://github.com/vbauer/lein-plantuml"
   :license {:name "Eclipse Public License"
@@ -6,7 +6,7 @@
 
   :dependencies [[org.apache.xmlgraphics/batik-rasterizer "1.10"]
                  [org.apache.xmlgraphics/fop-pdf-images "2.3" :exclusions [commons-logging]]
-                 [net.sourceforge.plantuml/plantuml "8059"]
+                 [net.sourceforge.plantuml/plantuml "1.2021.9"]
                  [commons-io "2.5"]
                  [me.raynes/fs "1.4.6" :exclusions [org.clojure/clojure]]]
 


### PR DESCRIPTION
@vbauer Thanks for this plugin! This PR bumps the PlantUML dependency to the latest version.

The biggest advantage of this change is that now this plugin works for PlantUML files depending on the [plantuml-stdlib](https://github.com/plantuml/plantuml-stdlib), which is now included in the PlantUML release.

- [x] PlantUML dependency bumped from version `8059` to `1.2021.9`
- [x] `lein test` passes on this change

Maven coordinates for the new PlantUML releases are here:
- https://repo1.maven.org/maven2/net/sourceforge/plantuml/plantuml/
- https://search.maven.org/artifact/net.sourceforge.plantuml/plantuml